### PR TITLE
Rename herokuapp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ deploy:
   provider: heroku
   api_key:
     secure: d3IRhxZYHkOHkAERn/1KCiHgybrlJH3QI5zTafxqMXa/jQ4eVjCEk/3GHDP97QhjG4wDD/+0DzrKvxxXWS8HJFKMGjhq82qhkQSxBQvaR1D184ZNdlCntT3R4B4YjRQJQV4zJjj2DeGHrgoUNaODUGOzsaollmWKqbe19ULaURga3eEaIxM/QWwowcWsJXQMLdgxUC/AkPlwmjZrezGc/3jZreWtCxg98JzkN4zrMzFsIUINB8ABteBlyc+dpclGkjW8gSOFi/2b56lMk//es24ldjhQ1wSNprSx8aTNgkYC3Pd6ZZsjFSRzTWaKIZOyKOv92ZCN99ORWd9AymkhE1tXAFO1Or47KmrKOddx7sMCHRZYcL06oknk+NC7qSpYFxOFGxdjW363WWni2RMHR1XhfRRBlU3pc5eBTiq1s8idbuNvxs28QEKe6VzyM6UB6/ce89qEzlC2ZCJ9PKBYZW8HtzTUZ2SZBMCQ8Y6tGqpYJGuVK+VyB50Y8gjQxvjXbJmnsL7thauY6+faBRq6MYnfsVW4lT+/xMb7gFlbDinaPc5kGx29YM4fU2UX8qQKPfQKAN+0M7hlNRHSHPj7dfyWJ7it9hLJVJ11wUaIR/hIHeJa+nFKJ8GtoV2H70zZki89VobtI25RABEetDdJYVfLKvyCrD8HNX4c7iHQIXE=
-  app: lit-journey-4733
+  app: oyaco
   on:
-    repo: KahokuHanten/oyako
+    repo: KahokuHanten/oyaco
   run:
   - rake db:migrate
   - rake db:seed

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## OYACO
 [![Build Status](https://travis-ci.org/KahokuHanten/oyaco.svg?branch=master)](https://travis-ci.org/KahokuHanten/oyaco)
-* service: https://lit-journey-4733.herokuapp.com/
+* service: https://oyaco.herokuapp.com/
 * CI/test: https://travis-ci.org/KahokuHanten/oyaco
-* backlog: https://trello.com/b/W5HXXb1h/-
+* backlog: https://trello.com/b/W5HXXb1h/oyaco
 
 ### エレベーターピッチ
 


### PR DESCRIPTION
OYACOへの改名に伴い、Herokuとの連携が切れてました。
（ひとまず手動でアップデートしてあります）
.travis.ymlへの修正追加とHerokuのアプリ名も変更しました。http://oyaco.herokuapp.com

これで連携すればよいのですが、ダメだったら殷さん再設定お願いします。

