### PR TITLE
Google api の関数にエラーチェックを追加しました

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 class WelcomeController < ApplicationController
   # POST /
   def top
@@ -41,7 +42,7 @@ class WelcomeController < ApplicationController
     @message = MessageGenerator.new(@warnings).generate
 
     # Google search
-    @googlenews = LocalInfo.get_google_news(@pref_name)
+    @googlenews = LocalInfo.get_local_news(@pref_name)
 
     #趣味
     @hobby = params[:hobby]

--- a/lib/local_info.rb
+++ b/lib/local_info.rb
@@ -25,13 +25,11 @@ class LocalInfo
   end
 
   def self.get_google_news(pref_name)
-    searchtext = pref_name+" ニュース"
-    return GoogleCustomSearchApi.search(searchtext)
+    return LocalInfo::find_cse(pref_name+" ニュース",pref_name)
   end
 
   def self.get_hobby_news(hobby)
-    #GoogleCustomerSearch APIからニュースを取得する
-    hobby_result = GoogleCustomSearchApi.search(hobby)
+    hobby_result = LocalInfo::find_cse(hobby,hobby)
     hobbys = []
     result = {}
     if !hobby_result.has_key?("error") && !hobby_result["items"].blank? then
@@ -45,9 +43,14 @@ class LocalInfo
         end
       end
       result["items"] = hobbys
-    else 
-      #エラーメッセージを返却する
-      result["error"] = hobby + "に関するニュースは見つかりませんでした"
+    end
+    return result
+  end
+
+  def self.find_cse(search_text,error_preffix)
+    result = GoogleCustomSearchApi.search(search_text)
+    if result.has_key?("error") || result["items"].blank? then
+      result["error"] = error_preffix + "に関するニュースは見つかりませんでした"
     end
     return result
   end

--- a/lib/local_info.rb
+++ b/lib/local_info.rb
@@ -4,6 +4,8 @@ require 'nokogiri'
 
 class LocalInfo
   WW_URL = 'http://weather.livedoor.com/forecast/rss/warn/'
+  NEWS_NOT_FOUND_MESSAGE = 'に関するニュースは見つかりませんでした'
+  API_USAGE_LIMIT = '使用APIの回数制限のため、検索できませんでした'
 
   def self.get_weather_warnings(id)
     doc = ""
@@ -46,10 +48,13 @@ class LocalInfo
     return hobby_result
   end
 
-  def self.find_cse(search_text,error_preffix)
+  def self.find_cse(search_text,error_prefix)
     result = GoogleCustomSearchApi.search(search_text)
-    if result.has_key?("error") || result["items"].blank? then
-      result["error"] = error_preffix + "に関するニュースは見つかりませんでした"
+    errorReason = result["error"]["errors"][0]["reason"] rescue nil
+    if !errorReason.blank? && errorReason=="dailyLimitExceeded"
+      result["error_usage_limit"] = API_USAGE_LIMIT
+    elsif result.has_key?("error") || result["items"].blank? then
+      result["error"] = error_prefix + NEWS_NOT_FOUND_MESSAGE
     end
     return result
   end

--- a/lib/local_info.rb
+++ b/lib/local_info.rb
@@ -26,7 +26,7 @@ class LocalInfo
     messages
   end
 
-  def self.get_google_news(pref_name)
+  def self.get_local_news(pref_name)
     return LocalInfo::find_cse(pref_name+" ニュース",pref_name)
   end
 

--- a/lib/local_info.rb
+++ b/lib/local_info.rb
@@ -31,7 +31,6 @@ class LocalInfo
   def self.get_hobby_news(hobby)
     hobby_result = LocalInfo::find_cse(hobby,hobby)
     hobbys = []
-    result = {}
     if !hobby_result.has_key?("error") && !hobby_result["items"].blank? then
       hobby_result["items"].each do |a_news|
         #にっぽんもぎたて便の場合は返却する配列の先頭に挿入する
@@ -42,9 +41,9 @@ class LocalInfo
           hobbys.push(a_news)
         end
       end
-      result["items"] = hobbys
+      hobby_result["items"] = hobbys
     end
-    return result
+    return hobby_result
   end
 
   def self.find_cse(search_text,error_preffix)

--- a/lib/local_info.rb
+++ b/lib/local_info.rb
@@ -50,8 +50,8 @@ class LocalInfo
 
   def self.find_cse(search_text,error_prefix)
     result = GoogleCustomSearchApi.search(search_text)
-    errorReason = result["error"]["errors"][0]["reason"] rescue nil
-    if !errorReason.blank? && errorReason=="dailyLimitExceeded"
+    error_reason = result["error"]["errors"][0]["reason"] rescue nil
+    if !error_reason.blank? && error_reason=="dailyLimitExceeded"
       result["error_usage_limit"] = API_USAGE_LIMIT
     elsif result.has_key?("error") || result["items"].blank? then
       result["error"] = error_prefix + NEWS_NOT_FOUND_MESSAGE

--- a/test/GoogleNewsTest.rb
+++ b/test/GoogleNewsTest.rb
@@ -1,7 +1,0 @@
-# -*- coding: utf-8 -*-
-class GoogleNewsTest < ActiveSupport::TestCase
-  def test_get_google_news
-    news = LocalInfo.get_google_news("埼玉")
-    assert !news.empty?
-  end
-end

--- a/test/lib/local_info_test.rb
+++ b/test/lib/local_info_test.rb
@@ -12,12 +12,15 @@ class LocalInfoTest < ActiveSupport::TestCase
     assert_nil LocalInfo.get_weather_warnings(100)
   end
 
-=begin
   test "should get google news" do
     news = LocalInfo.get_google_news("埼玉")
-    assert !news.has_key?("error")
+    if !news.has_key?("error") then
+      assert !news["items"].blank?
+    else
+      assert !news["error"].blank?
+    end
+
   end
-=end
 
   test "should get any hobby news or error message" do
     hobby_news = LocalInfo.get_hobby_news("イラスト")

--- a/test/lib/local_info_test.rb
+++ b/test/lib/local_info_test.rb
@@ -13,25 +13,30 @@ class LocalInfoTest < ActiveSupport::TestCase
   end
 
   test "should get google news" do
-    news = LocalInfo.get_google_news("埼玉")
-    if !news.has_key?("error") then
+    pref = "埼玉"
+    news = LocalInfo.get_google_news(pref)
+    if news.has_key?("items")&&!news["items"].blank? then
       assert !news["items"].blank?
+    elsif news.has_key?("error_usage_limit") then
+      assert_equal(LocalInfo::API_USAGE_LIMIT,news["error_usage_limit"])
     else
-      assert !news["error"].blank?
+      assert_equal(pref+LocalInfo::NEWS_NOT_FOUND_MESSAGE,news["error"]) 
     end
-
   end
 
   test "should get any hobby news or error message" do
-    hobby_news = LocalInfo.get_hobby_news("イラスト")
-    if hobby_news.has_key?("items") then
+    hobby = "イラスト"
+    hobby_news = LocalInfo.get_hobby_news(hobby)
+    if hobby_news.has_key?("items")&&!hobby_news["items"].blank? then
       link = nil
       hobby_news["items"].first(1).each do |a_news|
         link = a_news["link"]
       end
       assert !link.blank?
+    elsif hobby_news.has_key?("error_usage_limit") then
+      assert_equal(LocalInfo::API_USAGE_LIMIT,hobby_news["error_usage_limit"])
     else
-      assert !hobby_news["error"].blank?
+      assert_equal(hobby+LocalInfo::NEWS_NOT_FOUND_MESSAGE,hobby_news["error"]) 
     end
   end
 end

--- a/test/lib/local_info_test.rb
+++ b/test/lib/local_info_test.rb
@@ -12,9 +12,9 @@ class LocalInfoTest < ActiveSupport::TestCase
     assert_nil LocalInfo.get_weather_warnings(100)
   end
 
-  test "should get google news" do
+  test "should get local news" do
     pref = "埼玉"
-    news = LocalInfo.get_google_news(pref)
+    news = LocalInfo.get_local_news(pref)
     if news.has_key?("items")&&!news["items"].blank? then
       assert !news["items"].blank?
     elsif news.has_key?("error_usage_limit") then


### PR DESCRIPTION
LocalInfoのget_google_newsとget_hobby_newsにエラーチェックを追加しています。
ローカルで回数制限に達しても、正常に動作することを確認しています。