### PR TITLE
Validate telephone

### DIFF
--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -39,7 +39,8 @@
       <div class="form-group">
         <%= label_tag(:tel, "Q4: あなたのご両親の電話番号は？", class: "col-sm-6 control-label") %>
         <div class="col-sm-4">
-          <%= telephone_field_tag(:tel, cookies.signed[:tel] ||= "111", class: "form-control") %>
+          <%= telephone_field_tag(:tel, cookies.signed[:tel],
+            placeholder: "00-0000-0000", pattern: "^[0-9\-]+$", class: "form-control") %>
         </div>
       </div>
       <div class="form-group">

--- a/app/views/welcome/top.html.erb
+++ b/app/views/welcome/top.html.erb
@@ -83,7 +83,11 @@
   <div class="row">
     <div class="col-xs-4">
       <div class="text-center">
-        <%= link_to('電話する', 'tel:' + @tel, class: "btn btn-danger") %>
+        <% if @tel.present? %>
+          <%= link_to('電話する', 'tel:' + @tel, id: 'tel', class: "btn btn-danger") %>
+        <% else %>
+          <%= link_to('電話する', 'tel:' + @tel, id: 'tel', class: "btn btn-danger disabled") %>
+        <% end %>
       </div>
     </div>
     <div class="col-xs-4">

--- a/test/features/input_tel_test_test.rb
+++ b/test/features/input_tel_test_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class InputTelTestTest < Capybara::Rails::TestCase
+  test "user inputs valid number" do
+    visit root_path
+    within '#question-form' do
+      fill_in 'tel', with: '00-0000-0000'
+      click_button 'recommend'
+    end
+
+    refute page.find('#tel')[:class].include?("disabled")
+  end
+
+  test "user don't input number" do
+    visit root_path
+    within '#question-form' do
+      fill_in 'tel', with: ''
+      click_button 'recommend'
+    end
+
+    assert page.find('#tel')[:class].include?("disabled")
+  end
+end

--- a/test/features/input_tel_test_test.rb
+++ b/test/features/input_tel_test_test.rb
@@ -11,7 +11,7 @@ class InputTelTestTest < Capybara::Rails::TestCase
     refute page.find('#tel')[:class].include?("disabled")
   end
 
-  test "user don't input number" do
+  test "user doesn't input number" do
     visit root_path
     within '#question-form' do
       fill_in 'tel', with: ''


### PR DESCRIPTION
電話番号のところは、数字とハイフンのみを許すことにしました。
空だった場合は、ボタンをDisabledにしました。