### PR TITLE
Fix back to result page

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -4,7 +4,7 @@ class WelcomeController < ApplicationController
 
   # GET /welcome
   def show
-    redirect_to root_path unless cookies.signed[:dad]
+    return redirect_to root_path unless cookies.signed[:dad]
 
     # get params from cookies
     [:dad, :mom, :pref_id, :tel, :hobby, :hobby2, :hobby3].each do |param|

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,13 +2,39 @@
 class WelcomeController < ApplicationController
   helper_method :smartphone?
 
-  # POST /
+  # GET /welcome
+  def show
+    redirect_to root_path unless cookies.signed[:dad]
+
+    # get params from cookies
+    [:dad, :mom, :pref_id, :tel, :hobby, :hobby2, :hobby3].each do |param|
+      params[param] = cookies.signed[param]
+    end
+    build_topics(params)
+    render :top
+  end
+
+  # POST /welcome
   def top
     # Set cookies
     [:dad, :mom, :pref_id, :tel, :hobby, :hobby2, :hobby3].each do |param|
       cookies.signed[param] = params[param]
     end
 
+    build_topics(params)
+    render :top
+  end
+
+  # DELETE /welcome
+  def clear
+    [:dad, :mom, :pref_id, :tel, :hobby, :hobby2, :hobby3].each do |param|
+      cookies.delete(param)
+    end
+    redirect_to root_path(anchor: "question")
+  end
+
+  private
+  def build_topics(params)
     # リクエストパラメータから都道府県コードを取得する
     @pref_id = params[:pref_id]
 
@@ -61,8 +87,6 @@ class WelcomeController < ApplicationController
     # 電話番号
     @tel = params[:tel]
   end
-
-  private
 
   def get_comment_by_event(holiday)
     case holiday.name

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -21,19 +21,19 @@
       <div class="form-group">
         <%= label_tag(:dad, "Q1: あなたのお父さんの誕生日は？", class: "col-sm-6 control-label") %>
         <div class="col-sm-4">
-          <%= date_field_tag(:dad, cookies.signed[:dad] ||= "1950-10-31", class: "form-control") %>
+          <%= date_field_tag(:dad, cookies.signed[:dad] || "1950-10-31", class: "form-control") %>
         </div>
       </div>
       <div class="form-group">
         <%= label_tag(:mom, "Q2: あなたのお母さんの誕生日は？", class: "col-sm-6 control-label") %>
         <div class="col-sm-4">
-          <%= date_field_tag(:mom, cookies.signed[:mom] ||= "1950-12-31", class: "form-control") %>
+          <%= date_field_tag(:mom, cookies.signed[:mom] || "1950-12-31", class: "form-control") %>
         </div>
       </div>
       <div class="form-group">
         <%= label_tag(:pref_id, "Q3: あなたのご両親のお住まいは？", class: "col-sm-6 control-label") %>
         <div class="col-sm-4">
-          <%= select_tag(:pref_id, options_from_collection_for_select(JpPrefecture::Prefecture.all, :code, :name, cookies.signed[:pref_id] ||= "1"), class: "form-control") %>
+          <%= select_tag(:pref_id, options_from_collection_for_select(JpPrefecture::Prefecture.all, :code, :name, cookies.signed[:pref_id] || "1"), class: "form-control") %>
         </div>
       </div>
       <div class="form-group">
@@ -46,9 +46,9 @@
       <div class="form-group">
         <%= label_tag(:hobby, "Q5: あなたのご両親の趣味は？", class: "col-sm-6 control-label") %>
         <div class="col-sm-4">
-          <%= text_field_tag(:hobby, cookies.signed[:hobby] ||= "温泉旅行", class: "form-control") %>
-          <%= text_field_tag(:hobby2, cookies.signed[:hobby2] ||= "ゴルフ", class: "form-control") %>
-          <%= text_field_tag(:hobby3, cookies.signed[:hobby3] ||= "落語", class: "form-control") %>
+          <%= text_field_tag(:hobby, cookies.signed[:hobby] || "温泉旅行", class: "form-control") %>
+          <%= text_field_tag(:hobby2, cookies.signed[:hobby2] || "ゴルフ", class: "form-control") %>
+          <%= text_field_tag(:hobby3, cookies.signed[:hobby3] || "落語", class: "form-control") %>
         </div>
       </div>
       <div class="form-group">

--- a/app/views/welcome/top.html.erb
+++ b/app/views/welcome/top.html.erb
@@ -105,7 +105,8 @@
     </div>
     <div class="col-xs-4">
       <div class="text-center">
-        <%= link_to('質問をやり直す', root_path(anchor: "question"), class: "btn btn-info btn-default") %>
+        <%= link_to('質問をやり直す', {controller: "welcome", action: "clear"}, method: "delete",
+          class: "btn btn-info btn-default") %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
   # You can have the root of your site routed with "root"
   root 'top#index'
 
+  get 'welcome' => 'welcome#show'
   post 'welcome' => 'welcome#top'
+  delete 'welcome' => 'welcome#clear'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -2,7 +2,8 @@
 require 'test_helper'
 
 class WelcomeControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "redirect without cookies" do
+    get :show, :dad => nil
+    assert_redirected_to root_path
+  end
 end

--- a/test/features/get_topics_test.rb
+++ b/test/features/get_topics_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class GetTopicsTest < Capybara::Rails::TestCase
+  test "user get topics after input form" do
+    visit root_path
+    within '#question-form' do
+      select '大阪府', from: 'pref_id'
+      click_button 'recommend'
+    end
+    visit root_path
+    visit welcome_path
+
+    assert_content page, "大阪府"
+  end
+end

--- a/test/features/get_topics_test.rb
+++ b/test/features/get_topics_test.rb
@@ -7,9 +7,20 @@ class GetTopicsTest < Capybara::Rails::TestCase
       select '大阪府', from: 'pref_id'
       click_button 'recommend'
     end
+
     visit root_path
+    
     visit welcome_path
 
     assert_content page, "大阪府"
+  end
+
+  test "user redirect to root before input form" do
+    browser = Capybara.current_session.driver.browser
+    browser.clear_cookies
+
+    visit welcome_path
+
+    assert_equal page.current_path, "/"
   end
 end

--- a/test/features/remember_inputs_test.rb
+++ b/test/features/remember_inputs_test.rb
@@ -27,7 +27,7 @@ class RememberInputsTest < Capybara::Rails::TestCase
       click_button 'recommend'
     end
 
-    Capybara.current_session.reset!
+    click_on '質問をやり直す'
 
     visit root_path
 


### PR DESCRIPTION
ブラウザの戻るでエラーになる問題の修正に付随した変更です。
- これまでGETでアクセスするとエラーになっていましたが、Cookieがあれば結果を表示、なければトップに戻るという仕様で、GETでのアクセスを許しました。これによりChromeがGETで戻ってきても、結果的に問題なくなりました。
- トップ画面表示時点で、Cookieに初期値がセットされてしまっていたのを修正しました（Submitすることでセットされます）。
- 質問をやり直すで、Cookieを削除するようにしました。


