### PR TITLE
Clear subscription_id in DB

### DIFF
--- a/app/assets/javascripts/push_messaging/main.js.erb
+++ b/app/assets/javascripts/push_messaging/main.js.erb
@@ -81,11 +81,22 @@ function sendSubscription(mergedEndpoint) {
 */
 }
 
+function clearSubscription() {
+  $.post(
+    "welcome/clear_subscription_id"
+    ,""
+    ,function(res){
+      if(res!='error'){
+        alert("プッシュ通知を解除しました。")
+      }
+  });
+}
+
 function unsubscribe() {
   var pushButton = document.querySelector('.js-push-button');
   pushButton.disabled = true;
 //  curlCommandDiv.textContent = '';
-
+  clearSubscription();
   navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
     // To unsubscribe from push messaging, you need get the
     // subcription object, which you can call unsubscribe() on.

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -43,6 +43,15 @@ class WelcomeController < ApplicationController
     if current_or_guest_user
       current_or_guest_user.update_attribute(:subscription_id, subscription_id)
     end
+    render nothing: true
+  end
+
+  # POST /welcome/clear_subscription_id
+  def clear_subscription_id
+    if current_or_guest_user
+      current_or_guest_user.update_attribute(:subscription_id, nil)
+    end
+    render nothing: true
   end
 
   private
@@ -54,12 +63,12 @@ class WelcomeController < ApplicationController
     @topics = []
 
     father = Person.new
-    father.assign_attributes(relation: 0, 
-                             birthday: @questionnaire.dad, 
+    father.assign_attributes(relation: 0,
+                             birthday: @questionnaire.dad,
                              location: params[:pref_id])
     mother = Person.new
-    mother.assign_attributes(relation: 1, 
-                             birthday: @questionnaire.mom, 
+    mother.assign_attributes(relation: 1,
+                             birthday: @questionnaire.mom,
                              location: params[:pref_id])
 
     [father, mother].each do |person|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,9 @@ Rails.application.routes.draw do
 
   get 'welcome' => 'welcome#show'
   post 'welcome' => 'welcome#top'
-  post 'welcome/save_subscription_id' => 'welcome#save_subscription_id'
   delete 'welcome' => 'welcome#clear'
+  post 'welcome/save_subscription_id' => 'welcome#save_subscription_id'
+  post 'welcome/clear_subscription_id' => 'welcome#clear_subscription_id'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'


### PR DESCRIPTION
プッシュ通知の解除時にDBのsubscription_idを削除するようにしました。
空のview templeteをなくして、render nithing: true にしました。