### PR TITLE
Setup sendgrid

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,6 +13,7 @@
     <% @users.each do |user| %>
       <tr>
         <td><%= user.name %></td>
+        <td><%= user.email %></td>
         <td><%= user.subscription_id %></td>
         <td><%= link_to 'Push', push_user_path(user), method: :post %></td>
         <td><%= link_to 'Show', user %></td>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,3 +7,13 @@ Rails.application.initialize!
 require 'local_info'
 require 'pref_name'
 require 'hobby'
+
+ActionMailer::Base.smtp_settings = {
+  :address        => 'smtp.sendgrid.net',
+  :port           => '587',
+  :authentication => :plain,
+  :user_name      => ENV['SENDGRID_USERNAME'],
+  :password       => ENV['SENDGRID_PASSWORD'],
+  :domain         => 'heroku.com',
+  :enable_starttls_auto => true
+}


### PR DESCRIPTION
Herokuにsendgridのaddonを追加して、メールを送れるようにしました（フリーで200通/日）。
試しにHerokuにあげてみて、パスワードリセットのメールが送られることを確認しました。
