### PR TITLE
Update login view

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -2,8 +2,11 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
+body { padding-top: 60px; }
+
 /* Top */
 .landing_top {
+  overflow-x: hidden; // remove right margin for iPhone
   display: table;
   position: relative;
   width: 100%;

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,23 @@
-<h2>Forgot your password?</h2>
+<div class="container">
+  <div class="row">
+    <div class="col-sm-6 col-sm-offset-3">
+      <div class="light-well">
+        <h3 class="page-header text-center">パスワードを忘れましたか？</h3>
+        <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+          <%= devise_error_messages! %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+          <div class="form-group">
+            <%= f.email_field :email, autofocus: true, placeholder: "Email Address", class: "form-control" %>
+          </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+          <div class="actions">
+            <%= f.submit "パスワード再設定のためのメールを送信", class: "btn btn-success btn-default btn-block" %>
+          </div>
+        <% end %>
+      </div>
+      <br>
+      <br>
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,39 +1,48 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="container">
+  <div class="row">
+    <div class="col-sm-6 col-sm-offset-3">
+      <div class="light-well">
+        <h3 class="page-header text-center">プロフィール変更</h3>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+        <%= form_for resource, as: resource_name, url: registration_path(resource_name), html: { method: :put },
+                      html: { class: "form-horizontal center"} do |f| %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+          <div class="form-group">
+            <%= f.email_field :email, autofocus: true, class: "form-control" %>
+          </div>
+
+          <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+            <div><%= resource.unconfirmed_email %> の確認待ち</div>
+          <% end %>
+
+          <div class="form-group">
+            <%= f.password_field :password, autocomplete: "off", placeholder: "New Password", class: "form-control" %>
+            <p class="help-block"><i>変更しない場合は空欄のまま</i><br />
+          </div>
+
+          <div class="form-group">
+            <%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "Confirm New Password", class: "form-control" %>
+            <% if @validatable %>
+              <p class="help-block"><%= @minimum_password_length %> characters minimum</p>
+            <% end %>
+          </div>
+
+          <div class="form-group">
+            <%= f.password_field :current_password, autocomplete: "off", placeholder: "Current Password", class: "form-control" %>
+            <p class="help-block"><i>変更を反映するには、現在のパスワードを入力してください</i><br />
+          </div>
+
+          <div class="actions">
+            <%= f.submit "更新", class: "btn btn-success btn-default btn-block" %>
+          </div>
+          <%= devise_error_messages! %>
+        <% end %>
+      </div>
+      <br>
+      <br>
+      <h3 class="page-header text-center">アカウント削除</h3>
+      <p><%= button_to "アカウント削除", registration_path(resource_name), class: "btn btn-danger btn-default btn-block", data: { confirm: "本当にいいですか？" }, method: :delete %></p>
+      <%= link_to "戻る", :back %>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,37 @@
-<h2>Sign up</h2>
+<div class="container">
+  <div class="row">
+    <div class="col-sm-6 col-sm-offset-3">
+      <div class="light-well">
+        <h3 class="page-header text-center">ユーザー登録</h3>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= devise_error_messages! %>
+        <%= form_for resource, as: resource_name, url: registration_path(resource_name),
+                      html: { class: "form-horizontal center"} do |f| %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+        <div class="form-group">
+          <%= f.email_field :email, autofocus: true, placeholder: "Email Address", class: "form-control" %>
+        </div>
+
+        <div class="form-group">
+          <%= f.password_field :password, autocomplete: "off", placeholder: "Password", class: "form-control" %>
+        </div>
+
+        <div class="form-group">
+          <%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "Confirm Password", class: "form-control" %>
+          <% if @validatable %>
+          <p class="help-block"><%= @minimum_password_length %>
+            characters minimum</p>
+          <% end %>
+        </div>
+
+        <div class="actions">
+          <%= f.submit "ユーザー登録", class: "btn btn-success btn-default btn-block" %>
+        </div>
+        <%= devise_error_messages! %>
+        <% end %>
+      </div>
+      <br>
+      <br>
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,40 @@
-<h2>Log in</h2>
+<div class="container">
+  <div class="row">
+    <div class="col-sm-6 col-sm-offset-3">
+      <div class="light-well">
+        <h3 class="page-header text-center">ログイン</h3>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
-  </div>
+        <%= form_for resource, as: resource_name, url: session_path(resource_name),
+                      html: { class: "form-horizontal center"} do |f| %>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
+          <div class="form-group">
+            <%= f.email_field :email, autofocus: true, placeholder: "Email Address", class: "form-control" %>
+          </div>
 
-  <% if devise_mapping.rememberable? -%>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+          <div class="form-group">
+            <%= f.password_field :password, autocomplete: "off", placeholder: "Password", class: "form-control" %>
+          </div>
+
+          <% if devise_mapping.rememberable? -%>
+            <div class="form-group">
+              <div class="col-sm-10">
+                <div class="checkbox">
+                  <label>
+                    <%= f.check_box :remember_me %> <%= "#{t "Remember me"}" %>
+                  </label>
+                </div>
+              </div>
+            </div>
+          <% end -%>
+
+          <div class="actions">
+            <%= f.submit "ログイン", class: "btn btn-success btn-default btn-block" %>
+          </div>
+        <% end %>
+      </div>
+      <br>
+      <br>
+      <%= render "devise/shared/links" %>
     </div>
-  <% end -%>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,21 +1,21 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "ログイン", new_session_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "ユーザー登録", new_registration_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードを忘れましたか？", new_password_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "確認メールの再送信", new_confirmation_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to "アカウント凍結解除メールの再送信", new_unlock_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,1 +1,1 @@
-<a href=""><small>Copyright &copy 2015 KahokuHanten All Rights Reserved.</small></a>
+<small>Copyright &copy 2015 KahokuHanten All Rights Reserved.</small>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,1 @@
+<a href=""><small>Copyright &copy 2015 KahokuHanten All Rights Reserved.</small></a>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,46 @@
+<nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+  <!--ウィンドウ幅に合わせて可変-->
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <!--スマホ用トグルボタンの設置-->
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <!--ロゴ表示の指定-->
+      <%= link_to "OYACO", root_path, class: "navbar-brand" %>
+    </div>
+    <!--スマホ用の画面幅が小さいときの表示を非表示にする-->
+    <div id="navbar" class="navbar-collapse collapse">
+      <ul class="nav navbar-nav">
+        <% if request.path == '/welcome' %>
+          <% if !(@tel.blank?) && smartphone? %>
+            <li><a id='tel' href="tel:<%= @tel %>">電話する</a></li>
+          <% end %>
+          <li><a href="javascript:void(0)" class="js-push-button">ブラウザ通知を登録する</a></li>
+          <li><%= link_to '質問をやり直す', {controller: "welcome", action: "clear"}, method: "delete" %></li>
+        <% end %>
+      </ul>
+      <ul class="nav navbar-nav navbar-right">
+        <% if user_signed_in? %>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">設定 <span class="caret"></span></a>
+            <ul class="dropdown-menu">
+              <li class="dropdown-header"><%= current_or_guest_user.email %></li>
+              <li role="separator" class="divider"></li>
+              <li role="separator" class="divider"></li>
+              <li><%= link_to "プロフィール変更", edit_user_registration_path %></li>
+              <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
+              <li><a href="#">Action</a></li>
+            </ul>
+          </li>
+        <% else %>
+          <li><%= link_to "ユーザー登録", new_user_registration_path %></li>
+          <li><%= link_to "ログイン", new_user_session_path %></li>
+        <% end %>
+      </ul>
+    </div><!--/.nav-collapse -->
+  </div><!--/.container-fluid -->
+</nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -30,10 +30,8 @@
             <ul class="dropdown-menu">
               <li class="dropdown-header"><%= current_or_guest_user.email %></li>
               <li role="separator" class="divider"></li>
-              <li role="separator" class="divider"></li>
               <li><%= link_to "プロフィール変更", edit_user_registration_path %></li>
               <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
-              <li><a href="#">Action</a></li>
             </ul>
           </li>
         <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,14 +18,22 @@
     <%= render 'layouts/header' %>
   </header>
 
-  <% if notice %>
-    <p class="alert alert-success"><%= notice %></p>
-  <% end %>
-  <% if alert %>
-    <p class="alert alert-danger"><%= alert %></p>
+  <%= yield %>
+
+  <% if notice.present? %>
+    <div class="alert alert-dismissable alert-success">
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+      <p><%= notice %></p>
+    </div>
   <% end %>
 
-  <%= yield %>
+  <% if alert.present? %>
+    <div class="alert alert-dismissable alert-danger">
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+      <p><%= alert %></p>
+    </div>
+  <% end %>
+
 
   <footer>
     <%= render 'layouts/footer' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,44 +15,7 @@
 </head>
 <body>
   <header>
-    <nav class="navbar navbar-default">
-      <!--ウィンドウ幅に合わせて可変-->
-      <div class="container-fluid">
-        <div class="navbar-header">
-          <!--スマホ用トグルボタンの設置-->
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <!--ロゴ表示の指定-->
-          <%= link_to "OYACO", root_path, class: "navbar-brand" %>
-        </div>
-        <!--スマホ用の画面幅が小さいときの表示を非表示にする-->
-        <div id="navbar" class="navbar-collapse collapse">
-          <ul class="nav navbar-nav">
-            <% if request.path == '/welcome' %>
-              <% if !(@tel.blank?) && smartphone? %>
-                <li><a id='tel' href="tel:<%= @tel %>">電話する</a></li>
-              <% end %>
-              <li><a href="javascript:void(0)" class="js-push-button">ブラウザ通知を登録する</a></li>
-              <li><%= link_to '質問をやり直す', {controller: "welcome", action: "clear"}, method: "delete" %></li>
-            <% end %>
-          </ul>
-          <ul class="nav navbar-nav navbar-right">
-            <% if user_signed_in? %>
-              <p class="navbar-text"><strong><%= current_or_guest_user.email %></strong>さん、こんにちは。</p>
-              <li><%= link_to "プロフィール変更", edit_user_registration_path %></li>
-              <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
-            <% else %>
-              <li><%= link_to "ユーザー登録", new_user_registration_path %></li>
-              <li><%= link_to "ログイン", new_user_session_path %></li>
-            <% end %>
-          </ul>
-        </div><!--/.nav-collapse -->
-      </div><!--/.container-fluid -->
-    </nav>
+    <%= render 'layouts/header' %>
   </header>
 
   <% if notice %>
@@ -65,7 +28,7 @@
   <%= yield %>
 
   <footer>
-    <a href=""><small>Copyright &copy 2015 KahokuHanten All Rights Reserved.</small></a>
+    <%= render 'layouts/footer' %>
   </footer>
 </body>
 </html>

--- a/app/views/welcome/top.html.erb
+++ b/app/views/welcome/top.html.erb
@@ -11,82 +11,65 @@
 <li><a href="#tab2" data-toggle="tab">ローカル</a></li>
 <li><a href="#tab3" data-toggle="tab">趣味</a></li>
 </ul>
-<!--タブコンテンツ-->
+<!-- タブコンテンツ -->
 <div id="myTabContent" class="tab-content">
+  <!-- イベント -->
   <div class="tab-pane fade in active" id="tab1">
-    <% @topics.each do |topic| %>
-    <div class="popover-message">
-      <div class="">
-        <div class="popover right">
-          <div class="arrow"></div>
-          <h3 class="popover-title"><%= topic[:title] %></h3>
-          <div class="popover-content">
-            <p><%= topic[:comment] %></p>
-            <div class="row">
-              <div class="col-xs-1"></div>
-              <% topic[:items].first(3).each do |item| %>
-                <div class="col-xs-3">
-                  <a href="<%= item['affiliateUrl'] %>" target="_blank">
-                    <img class="img-responsive img-rounded" src="<%= item['mediumImageUrls'][0]['imageUrl'] %>">
-                  </a>
-                </div>
-              <% end %>
-            </div>
-
-            <% if topic[:message].present? %>
-              <p>こんな言葉を贈ってはどうですか？</p>
-              <p>「<%= topic[:message] %>」</p>
+    <ul class='list-group'>
+      <% @topics.each do |topic| %>
+        <li class='list-group-item'>
+          <h4 class="list-group-item-heading"><%= topic[:title] %></h4>
+          <p class="list-group-item-text"><%= topic[:comment] %></p>
+<!--
+          <div class="row">
+            <div class="col-xs-1"></div>
+            <% topic[:items].first(3).each do |item| %>
+              <div class="col-xs-3">
+                <a href="<%= item['affiliateUrl'] %>" target="_blank">
+                  <img class="img-responsive img-rounded" src="<%= item['mediumImageUrls'][0]['imageUrl'] %>">
+                </a>
+              </div>
             <% end %>
           </div>
-        </div>
-      </div>
-    </div>
-    <% end %>
+-->
+          <% if topic[:message].present? %>
+            <p>こんな言葉を贈ってはどうですか？</p>
+            <p>「<%= topic[:message] %>」</p>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
   </div>
+  <!-- ローカル -->
   <div class="tab-pane fade" id="tab2">
-    <div class="popover-message">
-      <div class="">
-        <div class="popover right">
-          <div class="arrow"></div>
-          <div class="popover-content">
-            <p><%= @pref_name %>は<%= @message %></p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="popover-message">
-      <div class="">
-        <div class="popover right">
-          <div class="arrow"></div>
-          <div class="popover-content">
-            <p><%= @pref_name %>のニュース</p>
-            <% if @googlenews["items"] %>
-              <% @googlenews["items"].first(3).each do |news| %>
-                <a href="<%= news["link"] %>"><%= news["title"] %><br></a>
-              <% end %>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    </div>
+    <ul class='list-group'>
+      <li class='list-group-item'>
+        <h4 class='list-group-item-heading'>お天気情報</h4>
+        <%= @pref_name %>は<%= @message %></p>
+      </li>
+      <li class='list-group-item'>
+        <h4 class='list-group-item-heading'><%= @pref_name %>のニュース</h4>
+        <% if @googlenews["items"] %>
+          <% @googlenews["items"].first(3).each do |news| %>
+            <a href="<%= news["link"] %>"><%= news["title"] %><br></a>
+          <% end %>
+        <% end %>
+      </li>
+    </ul>
   </div>
+  <!-- 趣味 -->
   <div class="tab-pane fade" id="tab3">
-    <% @hobbys.each do |hobby| %>
-    <div class="popover-message">
-      <div class="">
-        <div class="popover right">
-          <div class="arrow"></div>
-          <div class="popover-content">
-            <p>趣味<%= "（" << hobby[:name] << "）" %>のニュース</p>
-            <% if hobby[:news]["items"] %>
-              <% hobby[:news]["items"].first(3).each do |news| %>
-                <a href="<%= news["link"] %>"><%= news["title"] %><br></a>
-              <% end %>
+    <ul class='list-group'>
+      <% @hobbys.each do |hobby| %>
+        <li class='list-group-item'>
+          <h4 class='list-group-item-heading'><%= hobby[:name] %>のニュース</h4>
+          <% if hobby[:news]["items"] %>
+            <% hobby[:news]["items"].first(3).each do |news| %>
+              <a href="<%= news["link"] %>"><%= news["title"] %><br></a>
             <% end %>
-          </div>
-        </div>
-      </div>
-    </div>
-    <% end %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module Oyaco
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.i18n.default_locale = :ja
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,71 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+ja:
+  "Sign in": "ログイン"
+  "Registration": "ユーザー登録"
+  "Sign up": "ユーザー登録"
+  "Update": "更新"
+  "Forgot your password?": "パスワード忘れはこちら"
+  "Send me reset password instructions": "パスワード再発行"
+  "Resend confirmation instructions": "パスワード再発行"
+  "Didn't receive confirmation instructions?": "確認メールの再送信"
+  "Didn't receive unlock instructions?": "アカウント凍結解除メールの再送信"
+  "Remember me": "次回からパスワード入力を省く"
+
+  devise:
+    confirmations:
+      confirmed: 'アカウントを登録しました。'
+      send_instructions: 'アカウントの有効化について数分以内にメールでご連絡します。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
+    failure:
+      already_authenticated: 'すでにログインしています。'
+      inactive: 'アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。'
+      invalid: "%{authentication_keys} もしくはパスワードが不正です。"
+      locked: 'あなたのアカウントは凍結されています。'
+      last_attempt: 'あなたのアカウントが凍結される前に、複数回の操作がおこなわれています。'
+      not_found_in_database: "%{authentication_keys} もしくはパスワードが不正です。"
+      timeout: 'セッションがタイムアウトしました。もう一度ログインしてください。'
+      unauthenticated: 'アカウント登録もしくはログインしてください。'
+      unconfirmed: 'メールアドレスの本人確認が必要です。'
+    mailer:
+      confirmation_instructions:
+        subject: 'アカウントの有効化について'
+      reset_password_instructions:
+        subject: 'パスワードの再設定について'
+      unlock_instructions:
+        subject: 'アカウントの凍結解除について'
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      no_token: "このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。"
+      send_instructions: 'パスワードの再設定について数分以内にメールでご連絡いたします。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。"
+      updated: 'パスワードが正しく変更されました。'
+      updated_not_active: 'パスワードが正しく変更されました。'
+    registrations:
+      destroyed: 'アカウントを削除しました。またのご利用をお待ちしております。'
+      signed_up: 'アカウント登録が完了しました。'
+      signed_up_but_inactive: 'ログインするためには、アカウントを有効化してください。'
+      signed_up_but_locked: 'アカウントが凍結されているためログインできません。'
+      signed_up_but_unconfirmed: '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。'
+      update_needs_confirmation: 'アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。'
+      updated: 'アカウント情報を変更しました。'
+    sessions:
+      signed_in: 'ログインしました。'
+      signed_out: 'ログアウトしました。'
+      already_signed_out: '既にログアウト済みです。'
+    unlocks:
+      send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      unlocked: 'アカウントを凍結解除しました。'
+  errors:
+    messages:
+      already_confirmed: 'は既に登録済みです。ログインしてください。'
+      confirmation_period_expired: "の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。"
+      expired: 'の有効期限が切れました。新しくリクエストしてください。'
+      not_found: 'は見つかりませんでした。'
+      not_locked: 'は凍結されていません。'
+      not_saved:
+        one: "エラーが発生したため %{resource} は保存されませんでした:"
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした:"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,195 @@
+---
+ja:
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      record_invalid: バリデーションに失敗しました %{errors}
+      restrict_dependent_destroy: "%{record}が存在しているので削除できません"
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: ギガバイト
+          kb: キロバイト
+          mb: メガバイト
+          tb: テラバイト
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: と
+      two_words_connector: と
+      words_connector: と
+  time:
+    am: 午前
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      short: "%y/%m/%d %H:%M"
+    pm: 午後


### PR DESCRIPTION
ログイン関係の見栄えを調整しました。ビューのみの変更です。

- ログイン後のアクションを「設定」メニュー以下に移動、navbarを画面固定に。
- iPhoneで見ると右に余白ができるのを回避
- 大きくなってきたapplication.html.erbを分割
- ログイン関係の文言をできるだけ日本語化、見栄えを調整
- 結果画面のポップオーバーがメニューの上に表示されるため、単なるリストに変更。画面案に合わせて商品イメージも一旦削除