### PR TITLE
Add username textbox

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,14 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   helper_method :current_or_guest_user
 
+  before_filter :configure_permitted_parameters, if: :devise_controller?
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.for(:sign_up) << :name
+    devise_parameter_sanitizer.for(:account_update) << :name
+  end
+
   def after_sign_out_path_for(resource)
     root_path
   end
@@ -62,4 +70,5 @@ class ApplicationController < ActionController::Base
     u.save!(validate: false)
     u
   end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :people, dependent: :destroy
+
+  validates :name, presence: true, length: { maximum: 50 }
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -8,16 +8,16 @@
                       html: { class: "form-horizontal center"} do |f| %>
 
           <div class="form-group">
-            <%= f.text_field :name, class: "form-control" ,placeholder: "User Name"%>
-          </div>
-
-          <div class="form-group">
             <%= f.email_field :email, autofocus: true, class: "form-control" %>
           </div>
 
           <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
             <div><%= resource.unconfirmed_email %> の確認待ち</div>
           <% end %>
+
+          <div class="form-group">
+            <%= f.text_field :name, class: "form-control" ,placeholder: "User Name"%>
+          </div>
 
           <div class="form-group">
             <%= f.password_field :password, autocomplete: "off", placeholder: "New Password", class: "form-control" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -8,6 +8,10 @@
                       html: { class: "form-horizontal center"} do |f| %>
 
           <div class="form-group">
+            <%= f.text_field :name, class: "form-control" ,placeholder: "User Name"%>
+          </div>
+
+          <div class="form-group">
             <%= f.email_field :email, autofocus: true, class: "form-control" %>
           </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,6 +8,10 @@
                       html: { class: "form-horizontal center"} do |f| %>
 
         <div class="form-group">
+          <%= f.text_field :name, class: "form-control" ,placeholder: "User Name"%>
+        </div>
+
+        <div class="form-group">
           <%= f.email_field :email, autofocus: true, placeholder: "Email Address", class: "form-control" %>
         </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,11 +8,11 @@
                       html: { class: "form-horizontal center"} do |f| %>
 
         <div class="form-group">
-          <%= f.text_field :name, class: "form-control" ,placeholder: "User Name"%>
+          <%= f.email_field :email, autofocus: true, placeholder: "Email Address", class: "form-control" %>
         </div>
 
         <div class="form-group">
-          <%= f.email_field :email, autofocus: true, placeholder: "Email Address", class: "form-control" %>
+          <%= f.text_field :name, class: "form-control" ,placeholder: "User Name"%>
         </div>
 
         <div class="form-group">

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,20 @@
+# -*- coding: utf-8 -*-
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end
+
+  test "should user name valid" do
+    user = User.create(name: 'テスト太郎',email:'oyaco@oyaco.com',password:'testtest')
+    assert user.valid?
+  end
+
+  test "should user name invalid" do
+    invalid_name = 'テスト太郎テスト太郎テスト太郎テスト太郎テスト太郎テスト太郎テスト太郎テスト太郎テスト太郎テスト太郎テ'
+    user = User.create(name: invalid_name ,email:'oyaco@oyaco.com',password:'testtest')
+    assert user.invalid?
+  end
+
 end


### PR DESCRIPTION
ログイン情報の登録・編集時にユーザ名を登録できるようにしました。

view：ユーザ名を追加
controller:nameパラメータを許可
test:nameパラメータのバリデーションのテストです。バリデーションはnameが50文字までとしました。

レビューお願いします。