### PR TITLE
Fix redirect loop

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
   end
 
   def show
-    return redirect_to root_path unless cookies.signed[:pref_id]
+    return redirect_to root_path if !user_signed_in? && !cookies.signed[:pref_id]
 
     @questionnaire = Questionnaire.new
     @questionnaire.restore_attributes_from_cookies(cookies)
@@ -52,12 +52,14 @@ class HomeController < ApplicationController
         items: (RakutenWebService::Ichiba::Item.search(keyword: holiday.name) unless holiday.name == "元日"),
         message: get_message_by_event(holiday))
     end
-    @pref_name = PrefName.get_pref_name(@pref_id)
-    @warnings = LocalInfo.get_weather_warnings(@pref_id)
-    @message = MessageGenerator.new(@warnings).generate
 
-    # Google search
-    @googlenews = LocalInfo.get_local_news(@pref_name)
+    # Local
+    if @pref_id.present?
+      @pref_name = PrefName.get_pref_name(@pref_id)
+      @warnings = LocalInfo.get_weather_warnings(@pref_id)
+      @message = MessageGenerator.new(@warnings).generate
+      @googlenews = LocalInfo.get_local_news(@pref_name)
+    end
 
     # 趣味
     @hobbys = []

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -43,6 +43,7 @@
   <!-- ローカル -->
   <div class="tab-pane fade" id="tab2">
     <ul class='list-group'>
+      <% if @pref_name.present? %>
       <li class='list-group-item'>
         <h4 class='list-group-item-heading'>お天気情報</h4>
         <%= @pref_name %>は<%= @message %></p>
@@ -56,6 +57,7 @@
         <% end %>
       </li>
     </ul>
+    <% end %>
   </div>
   <!-- 趣味 -->
   <div class="tab-pane fade" id="tab3">


### PR DESCRIPTION
Chromeでcookieがない状態でログインするとループする問題を修正しました。
- ログインしてれば/homeが見えるようにし、都道府県が未指定のときにはnilアクセスしないよう変更しました。