### PR TITLE
Add notice task

### DIFF
--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -1,3 +1,9 @@
 class Holiday < ActiveRecord::Base
   scope :soon, -> { where(date: Date.today..Date.today.months_since(Oyaco::Application.config.remind_months_ago)).order('date') }
+
+  notice_dates = []
+  (0..4).each do |i|
+    notice_dates.push(Date.current.days_since(i * 7))
+  end
+  scope :notice, -> { where("date IN (?)", notice_dates) }
 end

--- a/lib/tasks/notice.rake
+++ b/lib/tasks/notice.rake
@@ -1,20 +1,23 @@
-task :notice_task => :environment do
-  holidays = Holiday.notice
-  if holidays.count > 0
-    users = User.where("subscription_id is not null")
-    users.each do |user|
-      uri = URI.parse("https://android.googleapis.com/gcm/send")
-      https = Net::HTTP.new(uri.host, uri.port)
-      https.use_ssl = true
-      req = Net::HTTP::Post.new(uri.request_uri)
-      req["Content-Type"] = "application/json"
-      req["Authorization"] = "key=" + ENV['GOOGLE_API_KEY']
-      payload = {
-        'registration_ids': [user.subscription_id]
-      }.to_json
-      req.body = payload
-      res = https.request(req)
-      puts user.name, user.email, user.subscription_id, res.code, res.msg, res.body
+namespace :chrome_notice do
+  desc "祝日の当日、７日前、１４日前、２１日前、２８日前に、ブラウザへのプッシュ通知を実施"
+  task :notice_task => :environment do
+    holidays = Holiday.notice
+    if holidays.count > 0
+      users = User.where("subscription_id is not null")
+      users.each do |user|
+        uri = URI.parse("https://android.googleapis.com/gcm/send")
+        https = Net::HTTP.new(uri.host, uri.port)
+        https.use_ssl = true
+        req = Net::HTTP::Post.new(uri.request_uri)
+        req["Content-Type"] = "application/json"
+        req["Authorization"] = "key=" + ENV['GOOGLE_API_KEY']
+        payload = {
+          'registration_ids': [user.subscription_id]
+        }.to_json
+        req.body = payload
+        res = https.request(req)
+        puts user.name, user.email, user.subscription_id, res.code, res.msg, res.body
+      end
     end
   end
 end

--- a/lib/tasks/notice.rake
+++ b/lib/tasks/notice.rake
@@ -1,0 +1,20 @@
+task :notice_task => :environment do
+  holidays = Holiday.notice
+  if holidays.count > 0
+    users = User.where("subscription_id is not null")
+    users.each do |user|
+      uri = URI.parse("https://android.googleapis.com/gcm/send")
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+      req = Net::HTTP::Post.new(uri.request_uri)
+      req["Content-Type"] = "application/json"
+      req["Authorization"] = "key=" + ENV['GOOGLE_API_KEY']
+      payload = {
+        'registration_ids': [user.subscription_id]
+      }.to_json
+      req.body = payload
+      res = https.request(req)
+      puts user.name, user.email, user.subscription_id, res.code, res.msg, res.body
+    end
+  end
+end


### PR DESCRIPTION
祝日の当日、７日前、１４日前、２１日前、２８日前に、ブラウザへのプッシュ通知を実施するタスクを追加。
タスクの実行コマンド：bin/rake notice_task