### PR TITLE
add twitter time line

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -9,13 +9,14 @@
   <li role="presentation" class="active"><a href="#tab1" data-toggle="tab">イベント</a></li>
   <li role="presentation"><a href="#tab2" data-toggle="tab">ローカル</a></li>
   <li role="presentation"><a href="#tab3" data-toggle="tab">趣味</a></li>
-  <li role="presentation"><a href="#tab4" data-toggle="tab">つぶやき</a></li>
 </ul>
 <!-- タブコンテンツ -->
 <div id="myTabContent" class="tab-content">
   <!-- イベント -->
   <div class="tab-pane fade in active" id="tab1">
     <ul class='list-group'>
+      <div class="row">
+        <div class="col-xs-8">
       <% @topics.each do |topic| %>
         <li class='list-group-item'>
           <div class="row">
@@ -47,6 +48,12 @@
           <% end %>
         </li>
       <% end %>
+        </div>
+        <div class="col-xs-4">
+          <a class="twitter-timeline" href="https://twitter.com/search?q=%23%E8%A6%AA%E5%AD%9D%E8%A1%8C%20min_faves%3A1" data-widget-id="668742111487856640">#親孝行 min_faves:1に関するツイート</a>
+          <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+        </div>
+      </div>
       </ul>
   </div>
   <!-- ローカル -->
@@ -83,9 +90,4 @@
       <% end %>
     </ul>
   </div>
-  <!-- イベント -->
-  <div class="tab-pane fade in active" id="tab4">
-    <a class="twitter-timeline" href="https://twitter.com/search?q=%23%E8%A6%AA%E5%AD%9D%E8%A1%8C%20min_faves%3A1" data-widget-id="668742111487856640">#親孝行 min_faves:1に関するツイート</a>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-    </div>
 </div>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -85,6 +85,7 @@
   </div>
   <!-- イベント -->
   <div class="tab-pane fade in active" id="tab4">
-    <a class="twitter-timeline" href="https://twitter.com/hashtag/%E8%A6%AA%E3%81%AB%E6%84%9F%E8%AC%9D" data-widget-id="668742111487856640">#親に感謝 のツイート</a>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>  </div>
+    <a class="twitter-timeline" href="https://twitter.com/search?q=%23%E8%A6%AA%E5%AD%9D%E8%A1%8C%20min_faves%3A1" data-widget-id="668742111487856640">#親孝行 min_faves:1に関するツイート</a>
+    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+    </div>
 </div>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -9,6 +9,7 @@
   <li role="presentation" class="active"><a href="#tab1" data-toggle="tab">イベント</a></li>
   <li role="presentation"><a href="#tab2" data-toggle="tab">ローカル</a></li>
   <li role="presentation"><a href="#tab3" data-toggle="tab">趣味</a></li>
+  <li role="presentation"><a href="#tab4" data-toggle="tab">つぶやき</a></li>
 </ul>
 <!-- タブコンテンツ -->
 <div id="myTabContent" class="tab-content">
@@ -46,7 +47,7 @@
           <% end %>
         </li>
       <% end %>
-    </ul>
+      </ul>
   </div>
   <!-- ローカル -->
   <div class="tab-pane fade" id="tab2">
@@ -82,4 +83,8 @@
       <% end %>
     </ul>
   </div>
+  <!-- イベント -->
+  <div class="tab-pane fade in active" id="tab4">
+    <a class="twitter-timeline" href="https://twitter.com/hashtag/%E8%A6%AA%E3%81%AB%E6%84%9F%E8%AC%9D" data-widget-id="668086130168827904">#親に感謝 のツイート</a>
+    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>  </div>
 </div>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -85,6 +85,6 @@
   </div>
   <!-- イベント -->
   <div class="tab-pane fade in active" id="tab4">
-    <a class="twitter-timeline" href="https://twitter.com/hashtag/%E8%A6%AA%E3%81%AB%E6%84%9F%E8%AC%9D" data-widget-id="668086130168827904">#親に感謝 のツイート</a>
+    <a class="twitter-timeline" href="https://twitter.com/hashtag/%E8%A6%AA%E3%81%AB%E6%84%9F%E8%AC%9D" data-widget-id="668742111487856640">#親に感謝 のツイート</a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>  </div>
 </div>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -16,11 +16,11 @@
   <div class="tab-pane fade in active" id="tab1">
     <ul class='list-group'>
       <div class="row">
-        <div class="col-xs-8">
+        <div class="col-xs-7">
       <% @topics.each do |topic| %>
         <li class='list-group-item'>
           <div class="row">
-          <div class="col-xs-9">
+          <div class="col-xs-8">
             <h4 class="list-group-item-heading"><%= topic[:title] %></h4>
             <% if topic[:wikipedia].present? %>
             <p class="list-group-item-text wikipedia">
@@ -49,7 +49,7 @@
         </li>
       <% end %>
         </div>
-        <div class="col-xs-4">
+        <div class="col-xs-5">
           <a class="twitter-timeline" href="https://twitter.com/search?q=%23%E8%A6%AA%E5%AD%9D%E8%A1%8C%20min_faves%3A1" data-widget-id="668742111487856640">#親孝行 min_faves:1に関するツイート</a>
           <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
         </div>


### PR DESCRIPTION
検索結果画面のイベントタブを左右に分割し、左にイベント情報、右にtwitterのつぶやきを表示するように
修正しました。

twitterの検索クエリで親孝行、記念日に関するハッシュタグ検索しています。

・検索クエリ
(#親孝行:) OR #親に感謝:) OR #親誕生日:) OR #結婚記念日:) OR #敬老の日:) OR #還暦:) OR #緑寿:) OR #古希:) OR #古稀:) OR #喜寿:) OR #傘寿:) OR #半寿:) OR #盤寿:) OR #米寿:) OR #卒寿:) OR #卆寿:) OR #白寿:) OR #百寿:) OR #長寿:)) AND (min_faves:1 OR min_retweets:1 OR min_replies:1)
